### PR TITLE
Add u-boot-tools and pigz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN apt-get update && \
     systemd \
     dbus \
     unzip \
+    u-boot-tools \
+    pigz \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/github.com/go-debos/debos/debos /usr/bin/debos


### PR DESCRIPTION
u-boot-tools is needed to compile boot.txt uboot script
pigz is uses for parallel/multicore gzip compression